### PR TITLE
Do not launch NVDA after install

### DIFF
--- a/nvda/tools/chocolateyInstall.ps1
+++ b/nvda/tools/chocolateyInstall.ps1
@@ -2,6 +2,6 @@
 $packageVersion = '2016.1'
 $fileType = 'exe'
 $url = "https://www.nvaccess.org/download/nvda/releases/$packageVersion/nvda_$packageVersion.exe"
-$silentArgs = '--install'
+$silentArgs = '--install-silent'
 
 Install-ChocolateyPackage $packageName $fileType $silentArgs $url


### PR DESCRIPTION
Use `--install-silent` instead of `--install`. This prevents launch of NVDA after the install. See [nvda.pyw#L81](https://github.com/nvaccess/nvda/blob/1684dc53d01baa50f9c10c9a85fd2ad0cc323480/source/nvda.pyw#L81)
