### PR TITLE
Fix uninstall on 32-bit Windows

### DIFF
--- a/nvda/tools/chocolateyUninstall.ps1
+++ b/nvda/tools/chocolateyUninstall.ps1
@@ -1,4 +1,10 @@
 $packageName = "nvda"
 $installerType = "exe"
+# http://stackoverflow.com/a/31793042/2154182
+if ("${env:ProgramFiles(x86)}") {
+    $programFiles86 = "${env:ProgramFiles(x86)}"
+} else {
+    $programFiles86 = "${env:ProgramFiles}"
+}
 
-Uninstall-ChocolateyPackage $packageName $installerType "/S" "${env:ProgramFiles(x86)}\nvda\uninstall.exe"
+Uninstall-ChocolateyPackage $packageName $installerType "/S" "${programFiles86}\nvda\uninstall.exe"


### PR DESCRIPTION
`%ProgramFiles(86)%` is not defined on 32-bit Windows. So use [this suggestion on StackOverflow](http://stackoverflow.com/a/31793042/2154182) to properly handle 32-bit Windows.

This error happens otherwise: https://gist.github.com/dusek/4fff86686cf9733858994ab9463c816d (most notable there is the "[ERROR] Running \nvda\uninstall.exe" which suggests `"C:\Program Files"` was not prepended)

I tried on 32-bit Windows that the programFiles86 variable contains `"C:\Program Files"`. I did not try running this new uninstaller (do not know yet how, new to chocolatey), nor did I try to make any tests on 64-bit Windows (have no easy access to one currently).
